### PR TITLE
Checkout v2.3.4 of TGM plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/tgm-plugin-activation"]
+	path = vendor/tgm-plugin-activation
+	url = git@github.com:TGMPA/TGM-Plugin-Activation.git


### PR DESCRIPTION
For some reason the TGM plugin submodule wasn't a submodule, but just a folder.  Maybe due to the exclusion of the .gitmodules file?
