### PR TITLE
Update config for TGM 2.5.0

### DIFF
--- a/includes/class-ga-top-content.php
+++ b/includes/class-ga-top-content.php
@@ -102,8 +102,8 @@ class GA_Top_Content {
 		$config = array(
 			'domain'           => 'top-google-posts',
 			'default_path'     => '',
-			'parent_menu_slug' => 'plugins.php',
-			'parent_url_slug'  => 'plugins.php',
+			'parent_slug'      => 'plugins.php',
+			'capability'       => 'install_plugins',
 			'menu'             => 'install-required-plugins',
 			'has_notices'      => true,
 			'is_automatic'     => true,


### PR DESCRIPTION
TGM 2.5.0 removed the `parent_menu_slug` and `parent_url_slug` configurations in favor of the `parent_slug` and `capability` options.

[TGM Configuration](http://tgmpluginactivation.com/configuration/)
