### PR TITLE
Add support for multiple post types on contentfilter

### DIFF
--- a/includes/class-dsgnwrks-google-top-posts-widgets.php
+++ b/includes/class-dsgnwrks-google-top-posts-widgets.php
@@ -80,16 +80,16 @@ class Dsgnwrks_Google_Top_Posts_Widgets extends WP_Widget {
 
 		<p><label>
 		<b>Limit Listings To:</b>
-		<select name="<?php echo $this->get_field_name( 'contentfilter' ); ?>">
+		<select name="<?php echo $this->get_field_name( 'contentfilter' ); ?>[]" multiple>
 		<?php
-		echo '<option value="allcontent" '. selected( esc_attr( $instance['contentfilter'] ), '' ) .'>Not Limited</option>';
+		echo '<option value="allcontent" '. selected( in_array( 'allcontent', $instance['contentfilter']), true ) .'>Not Limited</option>';
 
 		$content_types = get_post_types( array( 'public' => true ) );
 		foreach ( $content_types as $key => $value ) {
 			if ( 'attachment' == $value ) {
 				continue;
 			}
-			$selected_value = esc_attr( $instance['contentfilter'] ) == $key ? 'selected' : '';
+			$selected_value = in_array( $key, $instance['contentfilter']) ? 'selected' : '';
 			echo "<option value='". esc_attr( $key ) ."' $selected_value>$value</option>";
 		}
 		?>
@@ -167,7 +167,6 @@ class Dsgnwrks_Google_Top_Posts_Widgets extends WP_Widget {
 			'esc_attr' => array(
 				'title',
 				'time',
-				'contentfilter',
 				'catlimit',
 				'catfilter',
 				'postfilter',
@@ -189,6 +188,12 @@ class Dsgnwrks_Google_Top_Posts_Widgets extends WP_Widget {
 			foreach ( $fields as $field ) {
 				$cleaned[ $field ] = $callback( isset( $new_instance[ $field ] ) ? $new_instance[ $field ] : '' );
 			}
+		}
+
+		if(in_array('allcontent', $new_instance['contentfilter'])){
+			$cleaned['contentfilter'] = array('allcontent');
+		} else {
+			$cleaned['contentfilter'] = $new_instance['contentfilter'];
 		}
 
 		$atts = shortcode_atts( $this->gatc->defaults, $cleaned, 'google_top_content' );

--- a/includes/class-ga-top-content.php
+++ b/includes/class-ga-top-content.php
@@ -180,6 +180,9 @@ class GA_Top_Content {
 
 		$atts = shortcode_atts( $this->defaults, $atts, 'google_top_content' );
 		$atts = apply_filters( 'gtc_atts_filter', $atts );
+		if(is_string($atts['contentfilter'])){
+			$atts['contentfilter'] = explode(',',$atts['contentfilter']);
+		}
 		$unique = md5( serialize( $atts ) );
 		$trans_id = 'gtc-'. $number . $unique;
 
@@ -259,7 +262,7 @@ class GA_Top_Content {
 			$wppost = null;
 			$thumb = '';
 
-			if ( 'allcontent' != $atts['contentfilter'] || '' != $atts['catlimit'] || '' != $atts['catfilter'] || '' != $atts['postfilter'] || ! empty( $atts['thumb_size'] ) ) {
+			if ( !in_array('allcontent',$atts['contentfilter']) || '' != $atts['catlimit'] || '' != $atts['catfilter'] || '' != $atts['postfilter'] || ! empty( $atts['thumb_size'] ) ) {
 
 				if ( false !== $default_permalink ) {
 					$wppost = get_post( (int) str_replace( '?p=', '', $path['filename'] ) );
@@ -280,16 +283,16 @@ class GA_Top_Content {
 					}
 				}
 
-				if ( $atts['contentfilter'] && 'allcontent' != $atts['contentfilter'] ) {
+				if ( $atts['contentfilter'] && !in_array('allcontent',$atts['contentfilter']) ) {
 					if ( empty( $wppost ) ) {
 						continue;
 					}
-					if ( $wppost->post_type != $atts['contentfilter'] ) {
+					if ( !in_array($wppost->post_type,$atts['contentfilter']) ) {
 						continue;
 					}
 				}
 
-				if ( 'allcontent' == $atts['contentfilter'] || 'post' == $atts['contentfilter'] ) {
+				if ( in_array('allcontent',$atts['contentfilter']) || in_array('post',$atts['contentfilter']) ) {
 
 					if ( $atts['catlimit'] != '' ) {
 						$limit_array = array();


### PR DESCRIPTION
If you have multiple post types (let's say, portfolio and posts, for example), and you want to show only those two, you couldn't in the past.

Now you can select multiple post types in the Content filter select (it is a multiple select now). Also, you set multiple too in the shortcode, separated by a comma. Example: 

`[google_top_content contentfilter=post,portfolio]`
