### PR TITLE
Feature/expose thumb in item filter

### DIFF
--- a/includes/class-ga-top-content.php
+++ b/includes/class-ga-top-content.php
@@ -340,7 +340,7 @@ class GA_Top_Content {
 				}
 			}
 
-			$list .= apply_filters( 'gtc_list_item', sprintf( $this->list_item_format(), $thumb, $url, $title ), $page, $wppost, $counter, $title, $url, $thumb );
+			$list .= apply_filters( 'gtc_list_item', sprintf( $this->list_item_format(), $thumb, $url, $title, $counter ), $page, $wppost, $counter, $title, $url, $thumb );
 
 			$counter++;
 

--- a/includes/class-ga-top-content.php
+++ b/includes/class-ga-top-content.php
@@ -340,7 +340,7 @@ class GA_Top_Content {
 				}
 			}
 
-			$list .= apply_filters( 'gtc_list_item', sprintf( $this->list_item_format(), $thumb, $url, $title ), $page, $wppost, $counter, $title, $url );
+			$list .= apply_filters( 'gtc_list_item', sprintf( $this->list_item_format(), $thumb, $url, $title ), $page, $wppost, $counter, $title, $url, $thumb );
 
 			$counter++;
 
@@ -505,7 +505,6 @@ class GA_Top_Content {
 		if ( ! $this->list_item_format ) {
 			$this->list_item_format = apply_filters( 'gtc_list_item_format', '<li>%1$s<a class="gtc-link" href="%2$s">%3$s</a></li>' );
 		}
-
 		return $this->list_item_format;
 	}
 


### PR DESCRIPTION
Hi,
I simply wanted to display an incremental counter in my items.

So, I first started using the gtc_list_item filter and make it expose $thumb (that was previously fetched, in your code).
Then, I also added $counter to gtcc_list_item_filter_format (which was a way better option).

Nevertheless, I thought the 2 options could suit some people, so I shared.
