### PR TITLE
Filter posts that are not published, for example: drafts

### DIFF
--- a/includes/class-ga-top-content.php
+++ b/includes/class-ga-top-content.php
@@ -324,6 +324,9 @@ class GA_Top_Content {
 						continue;
 					}
 				}
+				if($wppost->post_status != 'publish'){
+					continue;
+				}
 			}
 
 			$title = stripslashes( wp_filter_post_kses( apply_filters( 'gtc_page_title', $page['name'], $page, $wppost ) ) );


### PR DESCRIPTION
We were having this issue, that the widget showed draft posts if they had a lot of visits. This happened when there was a post with a lot of editing, and the editors kept looking at it in the frontend. It caused to generate a lot of pageviews in Google Analytics, and then appeared as a popular post, even it wasn't even published.

So I added this simple filter to discard posts that are not published.
