### PR TITLE
Update to support MonsterInsights > 6.0 + a few other things

### DIFF
--- a/google-analytics-top-posts-widget.php
+++ b/google-analytics-top-posts-widget.php
@@ -10,7 +10,7 @@
  * @link      http://j.ustin.co/rYL89n
  *
  * Plugin Name: Google Analytics Top Content Widget
- * Description: Widget and shortcode to display top content according to Google Analytics. ("Google Analytics by Yoast" plugin required)
+ * Description: Widget and shortcode to display top content according to Google Analytics. ("Google Analytics by MonsterInsights" plugin required)
  * Plugin URI:  http://j.ustin.co/yWTtmy
  * Author:      Jtsternberg
  * Author URI:  http://dsgnwrks.pro

--- a/includes/class-ga-top-content.php
+++ b/includes/class-ga-top-content.php
@@ -39,8 +39,8 @@ class GA_Top_Content {
 			'update'          => false,
 		);
 
-		// only do TGM Plugin Activation if we don't already have Yoast Google Analytics active
-		if ( ! class_exists( 'Yoast_GA_Admin' ) ) {
+		// only do TGM Plugin Activation if we don't already have MonsterInsights Google Analytics active
+		if ( ! defined( 'GAWP_VERSION' ) ) {
 			require_once GATC_DIR . 'vendor/tgm-plugin-activation/class-tgm-plugin-activation.php';
 			add_action( 'tgmpa_register', array( $this, 'register_required_plugins' ) );
 
@@ -94,7 +94,7 @@ class GA_Top_Content {
 
 		$plugins = array(
 			array(
-				'name'     => 'Google Analytics by Yoast',
+				'name'     => 'Google Analytics by MonsterInsights',
 				'slug'     => 'google-analytics-for-wordpress',
 				'required' => true,
 			),
@@ -139,12 +139,12 @@ class GA_Top_Content {
 	public function message_one() {
 		return sprintf(
 			'<p><strong>%s</strong></p><p><a href="%s" class="thickbox" title="%s">%s</a> | <a href="%s" class="thickbox" title="%s">%s</a>.</p>',
-			sprintf( __( 'The "Google Analytics Top Content" widget requires the plugin, %s, to be installed and activated.', 'gatpw' ), '<em>"Google Analytics by Yoast"</em>' ),
+			sprintf( __( 'The "Google Analytics Top Content" widget requires the plugin, %s, to be installed and activated.', 'gatpw' ), '<em>"Google Analytics by MonsterInsights"</em>' ),
 			admin_url( 'plugins.php?page=install-required-plugins' ),
-			__( 'Install Google Analytics by Yoast', 'gatpw' ),
+			__( 'Install Google Analytics by MonsterInsights', 'gatpw' ),
 			__( 'Install plugin', 'gatpw' ),
 			admin_url( 'plugins.php' ),
-			__( 'Activate Google Analytics by Yoast', 'gatpw' ),
+			__( 'Activate Google Analytics by MonsterInsights', 'gatpw' ),
 			__( 'Activate plugin', 'gatpw' )
 		);
 	}
@@ -152,14 +152,14 @@ class GA_Top_Content {
 	public function message_two() {
 		return sprintf(
 			'<p>%s</p><p><a href="%s">%s</a>.</p>',
-			__( 'You must first login to Google Analytics in the "Google Analytics by Yoast" settings for this widget to work.', 'gatpw' ),
+			__( 'You must first login to Google Analytics in the "Google Analytics by MonsterInsights" settings for this widget to work.', 'gatpw' ),
 			admin_url( 'admin.php?page=yst_ga_settings' ),
 			__( 'Go to plugin settings', 'gatpw' )
 		);
 	}
 
 	public function change_link_text( $complete_link_text ) {
-		return __( 'Go to "Google Analytics by Yoast" plugin settings', 'gatpw' );
+		return __( 'Go to "Google Analytics by MonsterInsights" plugin settings', 'gatpw' );
 	}
 
 	public function change_link_url( $complete_link_url ) {
@@ -170,7 +170,7 @@ class GA_Top_Content {
 		static $inline_style = false;
 		static $inline_style_done = false;
 
-		if ( ! class_exists( 'Yoast_Google_Analytics' ) ) {
+		if ( ! defined( 'GAWP_VERSION' ) ) {
 			return $this->message_one();
 		}
 
@@ -415,7 +415,7 @@ class GA_Top_Content {
 
 	public function views_shortcode( $atts = array(), $content = '' ) {
 
-		if ( ! $this->id() || ! class_exists( 'Yoast_Google_Analytics' ) ) {
+		if ( ! $this->id() || ! defined( 'GAWP_VERSION' ) ) {
 			return '';
 		}
 
@@ -464,7 +464,8 @@ class GA_Top_Content {
 			$count = 0;
 
 			if ( isset( $data['totalsForAllResults'] ) && is_array( $data['totalsForAllResults'] ) ) {
-				$count = reset( array_values( $data['totalsForAllResults'] ) );
+				$data  = array_values( $data['totalsForAllResults'] );
+				$count = reset( $data );
 			} elseif ( isset( $data['rows'] ) && is_array( $data['rows'] ) ) {
 				foreach ( $data['rows'] as $row ) {
 					$count = $count + $row[2];
@@ -495,8 +496,12 @@ class GA_Top_Content {
 
 	public function id() {
 		if ( is_null( $this->id ) ) {
-			$options = Yoast_GA_Options::instance()->options;
-			$this->id = isset( $options['analytics_profile'] ) ? $options['analytics_profile'] : '';
+			if ( defined( 'MONSTERINSIGHTS_VERSION' ) ) {
+				$this->id = monsterinsights_get_option( 'analytics_profile', false );
+			} else {
+				$options = Yoast_GA_Options::instance()->options;
+				$this->id = isset( $options['analytics_profile'] ) ? $options['analytics_profile'] : '';
+			}
 		}
 
 		return $this->id;
@@ -519,48 +524,65 @@ class GA_Top_Content {
 	}
 
 	public function make_request( $params, $context = '' ) {
-		if ( ! class_exists( 'Yoast_Google_Analytics' ) || ! defined( 'GAWP_FILE' ) ) {
-			trigger_error( 'GATC: ' . __( 'No requests can be made because Google Analytics Top Content Widget requires the Google Analytics by Yoast plugin to be installed and activated.', 'top-google-posts' ), E_USER_WARNING );
+		if ( ! defined( 'GAWP_VERSION' ) ) {
+			trigger_error( 'GATC: ' . __( 'No requests can be made because Google Analytics Top Content Widget requires the Google Analytics by MonsterInsights plugin to be installed and activated.', 'top-google-posts' ), E_USER_WARNING );
 			return;
 		}
 
-		$path = dirname( GAWP_FILE );
-		$files_to_include = array(
-			'Yoast_Google_CacheParser'      => '/vendor/yoast/api-libs/google/io/Google_CacheParser.php',
-			'Yoast_Google_Utils'            => '/vendor/yoast/api-libs/google/service/Google_Utils.php',
-			'Yoast_Google_HttpRequest'      => '/vendor/yoast/api-libs/google/io/Google_HttpRequest.php',
-			'Yoast_Google_IO'               => '/vendor/yoast/api-libs/google/io/Google_IO.php',
-			'Yoast_Google_WPIO'             => '/vendor/yoast/api-libs/google/io/Google_WPIO.php',
-			'Yoast_Google_Auth'             => '/vendor/yoast/api-libs/google/auth/Google_Auth.php',
-			'Yoast_Google_OAuth2'           => '/vendor/yoast/api-libs/google/auth/Google_OAuth2.php',
-			'Yoast_Google_Cache'            => '/vendor/yoast/api-libs/google/cache/Google_Cache.php',
-			'Yoast_Google_WPCache'          => '/vendor/yoast/api-libs/google/cache/Google_WPCache.php',
-			'Yoast_Google_Client'           => '/vendor/yoast/api-libs/google/Google_Client.php',
-			'Yoast_Google_Analytics_Client' => '/vendor/yoast/api-libs/googleanalytics/class-google-analytics-client.php',
-		);
+		if ( ! class_exists( 'MonsterInsights_GA' ) ) {
+			$path = dirname( GAWP_FILE );
+			$files_to_include = array(
+				'Yoast_Google_CacheParser'      => '/vendor/yoast/api-libs/google/io/Google_CacheParser.php',
+				'Yoast_Google_Utils'            => '/vendor/yoast/api-libs/google/service/Google_Utils.php',
+				'Yoast_Google_HttpRequest'      => '/vendor/yoast/api-libs/google/io/Google_HttpRequest.php',
+				'Yoast_Google_IO'               => '/vendor/yoast/api-libs/google/io/Google_IO.php',
+				'Yoast_Google_WPIO'             => '/vendor/yoast/api-libs/google/io/Google_WPIO.php',
+				'Yoast_Google_Auth'             => '/vendor/yoast/api-libs/google/auth/Google_Auth.php',
+				'Yoast_Google_OAuth2'           => '/vendor/yoast/api-libs/google/auth/Google_OAuth2.php',
+				'Yoast_Google_Cache'            => '/vendor/yoast/api-libs/google/cache/Google_Cache.php',
+				'Yoast_Google_WPCache'          => '/vendor/yoast/api-libs/google/cache/Google_WPCache.php',
+				'Yoast_Google_Client'           => '/vendor/yoast/api-libs/google/Google_Client.php',
+				'Yoast_Google_Analytics_Client' => '/vendor/yoast/api-libs/googleanalytics/class-google-analytics-client.php',
+			);
 
-		if ( version_compare( GAWP_VERSION, '5.4.3' ) >= 0 ) {
-			unset( $files_to_include['Yoast_Google_Analytics_Client'] );
-			$files_to_include['Yoast_Api_Google_Client'] = '/vendor/yoast/api-libs/class-api-google-client.php';
-		}
-
-		foreach ( $files_to_include as $class => $file ) {
-			if ( ! is_admin() || ! class_exists( $class, true ) ) {
-				require_once $path . $file;
+			if ( version_compare( GAWP_VERSION, '5.4.3' ) >= 0 ) {
+				unset( $files_to_include['Yoast_Google_Analytics_Client'] );
+				$files_to_include['Yoast_Api_Google_Client'] = '/vendor/yoast/api-libs/class-api-google-client.php';
 			}
-		}
 
-		$params = apply_filters( 'gtc_analytics_request_params', $params );
+			foreach ( $files_to_include as $class => $file ) {
+				if ( ! is_admin() || ! class_exists( $class, true ) ) {
+					require_once $path . $file;
+				}
+			}
 
-		if ( $context && is_scalar( $context ) ) {
-			$params = apply_filters( "gtc_analytics_{$context}_request_params", $params );
-		}
+			$params = apply_filters( 'gtc_analytics_request_params', $params );
 
-		$response = Yoast_Google_Analytics::get_instance()->do_request( add_query_arg( $params, 'https://www.googleapis.com/analytics/v3/data/ga' ) );
+			if ( $context && is_scalar( $context ) ) {
+				$params = apply_filters( "gtc_analytics_{$context}_request_params", $params );
+			}
 
-		return isset( $response['response']['code'] ) && 200 == $response['response']['code']
-			? wp_remote_retrieve_body( $response )
-			: false;
+			$response = Yoast_Google_Analytics::get_instance()->do_request( add_query_arg( $params, 'https://www.googleapis.com/analytics/v3/data/ga' ) );
+
+			return isset( $response['response']['code'] ) && 200 == $response['response']['code']
+				? wp_remote_retrieve_body( $response )
+				: false;
+			} else {
+				$mi = ( class_exists( 'MonsterInsights' ) ? MonsterInsights() : MonsterInsights_Lite() );
+				$ga = $mi->ga;
+
+				$params = apply_filters( 'gtc_analytics_request_params', $params );
+
+				if ( $context && is_scalar( $context ) ) {
+					$params = apply_filters( "gtc_analytics_{$context}_request_params", $params );
+				}
+
+				$response = $ga->do_request( add_query_arg( $params, 'https://www.googleapis.com/analytics/v3/data/ga' ) );
+
+				return isset( $response['response']['code'] ) && 200 == $response['response']['code']
+					? wp_remote_retrieve_body( $response )
+					: false;
+			}
 	}
 
 	public function parse_list_response( $body ) {

--- a/includes/class-ga-top-content.php
+++ b/includes/class-ga-top-content.php
@@ -150,12 +150,22 @@ class GA_Top_Content {
 	}
 
 	public function message_two() {
-		return sprintf(
+		$url = sprintf(
 			'<p>%s</p><p><a href="%s">%s</a>.</p>',
-			__( 'You must first login to Google Analytics in the "Google Analytics by MonsterInsights" settings for this widget to work.', 'gatpw' ),
+			__( 'You must first authenticate to Google Analytics in the "Google Analytics by MonsterInsights" settings for this widget to work.', 'gatpw' ),
 			admin_url( 'admin.php?page=yst_ga_settings' ),
 			__( 'Go to plugin settings', 'gatpw' )
 		);
+		if ( defined( 'MONSTERINSIGHTS_VERSION' ) ) {
+			$url = sprintf(
+				'<p>%s</p><p><a href="%s">%s</a>.</p>',
+				__( 'You must first authenticate to Google Analytics in the "Google Analytics by MonsterInsights" settings for this widget to work.', 'gatpw' ),
+				admin_url( 'admin.php?page=monsterinsights_settings' ),
+				__( 'Go to plugin settings', 'gatpw' )
+			);
+		}
+
+		return $url;
 	}
 
 	public function change_link_text( $complete_link_text ) {
@@ -163,7 +173,11 @@ class GA_Top_Content {
 	}
 
 	public function change_link_url( $complete_link_url ) {
-		return admin_url( 'admin.php?page=yst_ga_settings' );
+		$url = admin_url( 'admin.php?page=yst_ga_settings' );
+		if ( defined( 'MONSTERINSIGHTS_VERSION' ) ) {
+			$url = admin_url( 'admin.php?page=monsterinsights_settings' );
+		}
+		return $url;
 	}
 
 	public function top_content_shortcode( $atts = array(), $context = 'shortcode', $number = 0 ) {

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Widget and shortcode to display top content according to Google Analytics. ("Goo
 
 Adds a widget that allows you to display top pages/posts in your sidebar based on google analytics data.
 
-Requires a Google Analytics account, and the plugin, ["Google Analytics by MonsterInsights"](http://wordpress.org/extend/plugins/google-analytics-dashboard/) (which will be auto-installed by this plugin, thanks to [@jthomasgriffin](http://twitter.com/jthomasgriffin)'s awesome [TGM Plugin Activation Class](http://j.ustin.co/yZPKXw)).
+Requires a Google Analytics account, and the plugin, ["Google Analytics by MonsterInsights"](https://wordpress.org/plugins/google-analytics-for-wordpress/) (which will be auto-installed by this plugin, thanks to [@jthomasgriffin](http://twitter.com/jthomasgriffin)'s awesome [TGM Plugin Activation Class](http://j.ustin.co/yZPKXw)).
 
 Also includes a shortcode to display the top content in your posts and pages.
 

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 **Contributors:** jtsternberg  
 **Plugin Name:**  Google Analytics Top Content Widget  
 **Plugin URI:** http://j.ustin.co/yWTtmy  
-**Tags:** google analytics, google, top posts, top content, display rank, page rank, page views, widget, sidebar, sidebar widget, Google Analytics by Yoast, shortcode, site stats, statistics, stats  
+**Tags:** google analytics, google, top posts, top content, display rank, page rank, page views, widget, sidebar, sidebar widget, Google Analytics by MonsterInsights, shortcode, site stats, statistics, stats  
 **Author:** Jtsternberg  
 **Author URI:** http://dsgnwrks.pro  
 **Donate link:** http://j.ustin.co/rYL89n  
@@ -14,13 +14,13 @@
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
-Widget and shortcode to display top content according to Google Analytics. ("Google Analytics by Yoast" plugin required)
+Widget and shortcode to display top content according to Google Analytics. ("Google Analytics by MonsterInsights" plugin required)
 
 ## Description ##
 
 Adds a widget that allows you to display top pages/posts in your sidebar based on google analytics data.
 
-Requires a Google Analytics account, and the plugin, ["Google Analytics by Yoast"](http://wordpress.org/extend/plugins/google-analytics-dashboard/) (which will be auto-installed by this plugin, thanks to [@jthomasgriffin](http://twitter.com/jthomasgriffin)'s awesome [TGM Plugin Activation Class](http://j.ustin.co/yZPKXw)).
+Requires a Google Analytics account, and the plugin, ["Google Analytics by MonsterInsights"](http://wordpress.org/extend/plugins/google-analytics-dashboard/) (which will be auto-installed by this plugin, thanks to [@jthomasgriffin](http://twitter.com/jthomasgriffin)'s awesome [TGM Plugin Activation Class](http://j.ustin.co/yZPKXw)).
 
 Also includes a shortcode to display the top content in your posts and pages.
 
@@ -76,8 +76,8 @@ function gtc_add_viewcount_title( $pages ) {
 
 1. Upload the `google-analytics-top-posts-widget` directory to the `/wp-content/plugins/` directory.
 2. Activate the plugin through the 'Plugins' menu in WordPress.
-3. Plugin will prompt you to install the "Google Analytics by Yoast" plugin. Install and activate it.
-4. Use the "Google Analytics by Yoast" plugin's settings page to login to your google analytics account.
+3. Plugin will prompt you to install the "Google Analytics by MonsterInsights" plugin. Install and activate it.
+4. Use the "Google Analytics by MonsterInsights" plugin's settings page to authenticate to your google analytics account.
 5. On the widgets page, drag the "Google Analytics Top Posts" widget to the desired sidebar.
 6. Update the widget settings and save.
 
@@ -127,7 +127,7 @@ If you run into a problem or have a question, contact me ([contact form](http://
 * Fix the category limit filter in the widget settings.
 
 ### 1.6.7
-* Fixes "PHP Fatal error: Class 'Yoast_Api_Google_Client' not found" errors when trying to save posts with the shortcode. [Support thread](https://wordpress.org/support/topic/gatcw-plugin-shortcodes-cause-error-500?replies=9#post-7686527).
+* Fixes "PHP Fatal error: Class 'MonsterInsights_Api_Google_Client' not found" errors when trying to save posts with the shortcode. [Support thread](https://wordpress.org/support/topic/gatcw-plugin-shortcodes-cause-error-500?replies=9#post-7686527).
 
 ### 1.6.6
 * Use `url_to_postid()` to properly fetch a post ID from a url. [Support thread](https://wordpress.org/support/topic/gatcw-plugin-posts-not-displayed-when-permalinks-do-not-contain-post-slug).
@@ -139,7 +139,7 @@ If you run into a problem or have a question, contact me ([contact form](http://
 * Bug fix: Upgrade [TGM-Plugin-Activation](https://github.com/TGMPA/TGM-Plugin-Activation) to fix [an occasional issue](https://github.com/TGMPA/TGM-Plugin-Activation/issues/455#issuecomment-129684199).
 
 ### 1.6.3
-* Bug fix: "Google Analytics by Yoast" version 5.4.3 changed the name/location of their Google Analytics client class, so need to compensate
+* Bug fix: "Google Analytics by MonsterInsights" version 5.4.3 changed the name/location of their Google Analytics client class, so need to compensate
 
 ### 1.6.2
 * Update TGM-Plugin-Activation library.
@@ -149,7 +149,7 @@ If you run into a problem or have a question, contact me ([contact form](http://
 * New filters, 'gtc_analytics_request_params', and "gtc_analytics_{$context}_request_params" for modifying the request arguments to the Google Analytics API. (for things [like this](https://wordpress.org/support/topic/uniques-instead-of-raw-pageviews?replies=1))
 
 ### 1.6.0
-* Replaced dependency on 'Google Analytics Dashboard' plugin with a dependency on 'Google Analytics by Yoast'
+* Replaced dependency on 'Google Analytics Dashboard' plugin with a dependency on 'Google Analytics by MonsterInsights'
 * New filters, 'gtc_list_format' and 'gtc_list_item_format' for modifying the format of the list/list-item output
 
 ### 1.5.7

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Google Analytics Top Content Widget
 Contributors: jtsternberg
 Plugin Name:  Google Analytics Top Content Widget  
 Plugin URI: http://j.ustin.co/yWTtmy  
-Tags: google analytics, google, top posts, top content, display rank, page rank, page views, widget, sidebar, sidebar widget, Google Analytics by Yoast, shortcode, site stats, statistics, stats  
+Tags: google analytics, google, top posts, top content, display rank, page rank, page views, widget, sidebar, sidebar widget, Google Analytics by MonsterInsights, shortcode, site stats, statistics, stats  
 Author: Jtsternberg  
 Author URI: http://dsgnwrks.pro  
 Donate link: http://j.ustin.co/rYL89n  
@@ -15,13 +15,13 @@ Version: 1.6.9
 License: GPLv2 or later  
 License URI: http://www.gnu.org/licenses/gpl-2.0.html  
 
-Widget and shortcode to display top content according to Google Analytics. ("Google Analytics by Yoast" plugin required)
+Widget and shortcode to display top content according to Google Analytics. ("Google Analytics by MonsterInsights" plugin required)
 
 == Description ==
 
 Adds a widget that allows you to display top pages/posts in your sidebar based on google analytics data.
 
-Requires a Google Analytics account, and the plugin, ["Google Analytics by Yoast"](http://wordpress.org/extend/plugins/google-analytics-dashboard/) (which will be auto-installed by this plugin, thanks to [@jthomasgriffin](http://twitter.com/jthomasgriffin)'s awesome [TGM Plugin Activation Class](http://j.ustin.co/yZPKXw)).
+Requires a Google Analytics account, and the plugin, ["Google Analytics by MonsterInsights"](http://wordpress.org/extend/plugins/google-analytics-dashboard/) (which will be auto-installed by this plugin, thanks to [@jthomasgriffin](http://twitter.com/jthomasgriffin)'s awesome [TGM Plugin Activation Class](http://j.ustin.co/yZPKXw)).
 
 Also includes a shortcode to display the top content in your posts and pages.
 
@@ -75,8 +75,8 @@ Feel free to [fork or contribute on Github](https://github.com/jtsternberg/Googl
 
 1. Upload the `google-analytics-top-posts-widget` directory to the `/wp-content/plugins/` directory.
 2. Activate the plugin through the 'Plugins' menu in WordPress.
-3. Plugin will prompt you to install the "Google Analytics by Yoast" plugin. Install and activate it.
-4. Use the "Google Analytics by Yoast" plugin's settings page to login to your google analytics account.
+3. Plugin will prompt you to install the "Google Analytics by MonsterInsights" plugin. Install and activate it.
+4. Use the "Google Analytics by MonsterInsights" plugin's settings page to login to your google analytics account.
 5. On the widgets page, drag the "Google Analytics Top Posts" widget to the desired sidebar.
 6. Update the widget settings and save.
 
@@ -133,7 +133,7 @@ If you run into a problem or have a question, contact me ([contact form](http://
 * Bug fix: Upgrade [TGM-Plugin-Activation](https://github.com/TGMPA/TGM-Plugin-Activation) to fix [an occasional issue](https://github.com/TGMPA/TGM-Plugin-Activation/issues/455#issuecomment-129684199).
 
 = 1.6.3 =
-* Bug fix: "Google Analytics by Yoast" version 5.4.3 changed the name/location of their Google Analytics client class, so need to compensate
+* Bug fix: "Google Analytics by MonsterInsights" version 5.4.3 changed the name/location of their Google Analytics client class, so need to compensate
 
 = 1.6.2 =
 * Update TGM-Plugin-Activation library.
@@ -143,7 +143,7 @@ If you run into a problem or have a question, contact me ([contact form](http://
 * New filters, 'gtc_analytics_request_params', and "gtc_analytics_{$context}_request_params" for modifying the request arguments to the Google Analytics API. (for things [like this](https://wordpress.org/support/topic/uniques-instead-of-raw-pageviews?replies=1))
 
 = 1.6.0 =
-* Replaced dependency on 'Google Analytics Dashboard' plugin with a dependency on 'Google Analytics by Yoast'
+* Replaced dependency on 'Google Analytics Dashboard' plugin with a dependency on 'Google Analytics by MonsterInsights'
 * New filters, 'gtc_list_format' and 'gtc_list_item_format' for modifying the format of the list/list-item output
 
 = 1.5.7 =
@@ -234,7 +234,7 @@ If you were using the shortcode and it broke, you will need to switch to using t
 * Bug fix: Upgrade [TGM-Plugin-Activation](https://github.com/TGMPA/TGM-Plugin-Activation) to fix [an occasional issue](https://github.com/TGMPA/TGM-Plugin-Activation/issues/455#issuecomment-129684199).
 
 = 1.6.3 =
-* Bug fix: "Google Analytics by Yoast" version 5.4.3 changed the name/location of their Google Analytics client class, so need to compensate
+* Bug fix: "Google Analytics by MonsterInsights" version 5.4.3 changed the name/location of their Google Analytics client class, so need to compensate
 
 = 1.6.2 =
 * Update TGM-Plugin-Activation library.
@@ -244,7 +244,7 @@ If you were using the shortcode and it broke, you will need to switch to using t
 * New filters, 'gtc_analytics_request_params', and "gtc_analytics_{$context}_request_params" for modifying the request arguments to the Google Analytics API. (for things [like this](https://wordpress.org/support/topic/uniques-instead-of-raw-pageviews?replies=1))
 
 = 1.6.0 =
-* Replaced dependency on 'Google Analytics Dashboard' plugin with a dependency on 'Google Analytics by Yoast'
+* Replaced dependency on 'Google Analytics Dashboard' plugin with a dependency on 'Google Analytics by MonsterInsights'
 * New filters, 'gtc_list_format' and 'gtc_list_item_format' for modifying the format of the list/list-item output
 
 = 1.5.7 =

--- a/readme.txt
+++ b/readme.txt
@@ -21,7 +21,7 @@ Widget and shortcode to display top content according to Google Analytics. ("Goo
 
 Adds a widget that allows you to display top pages/posts in your sidebar based on google analytics data.
 
-Requires a Google Analytics account, and the plugin, ["Google Analytics by MonsterInsights"](http://wordpress.org/extend/plugins/google-analytics-dashboard/) (which will be auto-installed by this plugin, thanks to [@jthomasgriffin](http://twitter.com/jthomasgriffin)'s awesome [TGM Plugin Activation Class](http://j.ustin.co/yZPKXw)).
+Requires a Google Analytics account, and the plugin, ["Google Analytics by MonsterInsights"](https://wordpress.org/plugins/google-analytics-for-wordpress/) (which will be auto-installed by this plugin, thanks to [@jthomasgriffin](http://twitter.com/jthomasgriffin)'s awesome [TGM Plugin Activation Class](http://j.ustin.co/yZPKXw)).
 
 Also includes a shortcode to display the top content in your posts and pages.
 

--- a/readme.txt
+++ b/readme.txt
@@ -76,7 +76,7 @@ Feel free to [fork or contribute on Github](https://github.com/jtsternberg/Googl
 1. Upload the `google-analytics-top-posts-widget` directory to the `/wp-content/plugins/` directory.
 2. Activate the plugin through the 'Plugins' menu in WordPress.
 3. Plugin will prompt you to install the "Google Analytics by MonsterInsights" plugin. Install and activate it.
-4. Use the "Google Analytics by MonsterInsights" plugin's settings page to login to your google analytics account.
+4. Use the "Google Analytics by MonsterInsights" plugin's settings page to authenticate to your google analytics account.
 5. On the widgets page, drag the "Google Analytics Top Posts" widget to the desired sidebar.
 6. Update the widget settings and save.
 


### PR DESCRIPTION
Changes:

- Updated plugin to use the MI 6.0 classes for GA when MI >= 6.0.
- Changed verbiage from login to GA to authenticate with GA to match the MI plugin setting's button label
- Fixes #17 (needed to do a quick test of other changes)
- Fixes #14 for MI >= 6.0
- Added code to ensure correct admin settings page is used when MI >= 6.0
- Changed references from GA by Yoast to GA by MI to reflect the plugin name change