### PR TITLE
Support for non-ascii urls in `google_analytics_views` shortcode

### DIFF
--- a/includes/class-ga-top-content.php
+++ b/includes/class-ga-top-content.php
@@ -443,17 +443,26 @@ class GA_Top_Content {
 
 			$permalink = get_permalink( $atts['post_id'] );
 			$url_data  = parse_url( $permalink );
-			$link_uri  = substr( $url_data['path'] . ( isset( $url_data['query'] ) ? ( '?' . $url_data['query'] ) : '' ), -20 );
+			$link_uri  = urldecode( $url_data['path'] ) . ( isset( $url_data['query'] ) ? ( '?' . $url_data['query'] ) : '' );
+			$link_uri  = function_exists( 'mb_substr' ) ? mb_substr( $link_uri, -20 ) : substr( $link_uri, -20 );
 
 			if ( empty( $link_uri ) || 'draft' == get_post_status( $atts['post_id'] ) ) {
 				return '';
 			}
 
+			/**
+			 * Build GA $filters param and allow filtering
+			 *
+			 * @var string
+			 */
+			$filters = sprintf( 'ga:pagePath=~%s.*', $link_uri );
+			$filters = apply_filters( 'gtc_views_shortcode_ga_filters_param', $filters, $atts );
+
 			$params = array(
 				'ids'         => 'ga:'. $this->id(),
 				'dimensions'  => 'ga:pageTitle,ga:pagePath',
 				'metrics'     => 'ga:pageViews',
-				'filters'     => urlencode( 'ga:pagePath=~' . $link_uri . '.*' ),
+				'filters'     => urlencode( $filters ),
 				'max-results' => 100,
 				'start-date'  => $atts['start_date'],
 				'end-date'    => $atts['end_date'],


### PR DESCRIPTION
Since `get_permalink()` returns already urlencoded string `$link_uri` gets malformed by `urlencode()` on `'filters'` param if it contains non-ascii characters. My suggestion here is to do `urldecode( $url_data['path'] )` which will affect only non-ascii strings converting them to their multibyte(readable) states, then make use of `mb_substr()` if present with a fallback to regular `substr()`. 

Also because I wasn't able to change this behavior by just using a filter I placed one - `gtc_views_shortcode_ga_filters_param` - thinking that `filters` param is pretty important and probably good to be filterable.

I'm still unsure why we need a trim to 20 chars, can you please explain?