### PR TITLE
Removes no longer necessary class exists check

### DIFF
--- a/includes/class-ga-top-content.php
+++ b/includes/class-ga-top-content.php
@@ -645,7 +645,7 @@ class GA_Top_Content {
 
 		if ( class_exists( 'MonsterInsights_GA' ) ) {
 
-			$mi = class_exists( 'MonsterInsights' ) ? MonsterInsights() : MonsterInsights_Lite();
+			$mi = MonsterInsights();
 			$ga = $mi->ga;
 
 		} else {


### PR DESCRIPTION
Before we released MI 6 Lite we made a change so that this behavior is not needed anymore. MonsterInsights() simply returns either an instance of Pro if Pro is active or Lite if Lite is active